### PR TITLE
Add preliminary CGL MHD support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
         eos/eos.cpp
         eos/ideal_hyd.cpp
         eos/ideal_mhd.cpp
+        eos/cgl_mhd.cpp
         eos/isothermal_hyd.cpp
         eos/isothermal_mhd.cpp
         eos/ideal_srhyd.cpp

--- a/src/eos/cgl_mhd.cpp
+++ b/src/eos/cgl_mhd.cpp
@@ -1,0 +1,160 @@
+//==============================================================================
+// AthenaK astrophysical plasma code
+//------------------------------------------------------------------------------
+//! \file cgl_mhd.cpp
+//! \brief Skeleton implementation of CGL MHD.  Currently this simply reuses the
+//!        ideal MHD conversion routines and stores parallel and perpendicular
+//!        pressures in the first two scalar slots.  The flux calculations are
+//!        identical to the ideal MHD EOS.  This should be extended with full CGL
+//!        dynamics in the future.
+
+#include "athena.hpp"
+#include "mhd/mhd.hpp"
+#include "eos.hpp"
+#include "eos/ideal_c2p_mhd.hpp"
+
+//------------------------------------------------------------------------------
+// ctor
+CGLMHD::CGLMHD(MeshBlockPack *pp, ParameterInput *pin) :
+    EquationOfState("mhd", pp, pin) {
+  eos_data.is_ideal = true;
+  eos_data.gamma = pin->GetReal("mhd","gamma");
+  eos_data.iso_cs = 0.0;
+  eos_data.use_e = true;
+  eos_data.use_t = false;
+}
+
+//------------------------------------------------------------------------------
+//! \fn void ConsToPrim()
+//! \brief Converts conserved into primitive variables.  Parallel and
+//! perpendicular pressures are stored in scalar slots if present.
+
+void CGLMHD::ConsToPrim(DvceArray5D<Real> &cons, const DvceFaceFld4D<Real> &b,
+                        DvceArray5D<Real> &prim, DvceArray5D<Real> &bcc,
+                        const bool only_testfloors,
+                        const int il, const int iu, const int jl, const int ju,
+                        const int kl, const int ku) {
+  int &nmhd  = pmy_pack->pmhd->nmhd;
+  int &nscal = pmy_pack->pmhd->nscalars;
+  int &nmb = pmy_pack->nmb_thispack;
+  auto &eos = eos_data;
+  auto &fofc_ = pmy_pack->pmhd->fofc;
+
+  const int ni   = (iu - il + 1);
+  const int nji  = (ju - jl + 1)*ni;
+  const int nkji = (ku - kl + 1)*nji;
+  const int nmkji = nmb*nkji;
+
+  int nfloord_=0, nfloore_=0, nfloort_=0;
+  Kokkos::parallel_reduce("cglmhd_c2p",Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
+  KOKKOS_LAMBDA(const int &idx, int &sumd, int &sume, int &sumt) {
+    int m = (idx)/nkji;
+    int k = (idx - m*nkji)/nji;
+    int j = (idx - m*nkji - k*nji)/ni;
+    int i = (idx - m*nkji - k*nji - j*ni) + il;
+    j += jl;
+    k += kl;
+
+    MHDCons1D u;
+    u.d  = cons(m,IDN,k,j,i);
+    u.mx = cons(m,IM1,k,j,i);
+    u.my = cons(m,IM2,k,j,i);
+    u.mz = cons(m,IM3,k,j,i);
+    u.e  = cons(m,IEN,k,j,i);
+
+    if (only_testfloors) {
+      u.bx = bcc(m,IBX,k,j,i);
+      u.by = bcc(m,IBY,k,j,i);
+      u.bz = bcc(m,IBZ,k,j,i);
+    } else {
+      u.bx = 0.5*(b.x1f(m,k,j,i) + b.x1f(m,k,j,i+1));
+      u.by = 0.5*(b.x2f(m,k,j,i) + b.x2f(m,k,j+1,i));
+      u.bz = 0.5*(b.x3f(m,k,j,i) + b.x3f(m,k+1,j,i));
+    }
+
+    HydPrim1D w;
+    bool dfloor_used=false, efloor_used=false, tfloor_used=false;
+    SingleC2P_IdealMHD(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+
+    if (only_testfloors) {
+      if (dfloor_used || efloor_used || tfloor_used) {
+        fofc_(m,k,j,i) = true;
+        sumd++;
+      }
+    } else {
+      if (dfloor_used) {
+        cons(m,IDN,k,j,i) = u.d;
+        sumd++;
+      }
+      if (efloor_used) {
+        cons(m,IEN,k,j,i) = u.e;
+        sume++;
+      }
+      if (tfloor_used) {
+        cons(m,IEN,k,j,i) = u.e;
+        sumt++;
+      }
+      prim(m,IDN,k,j,i) = w.d;
+      prim(m,IVX,k,j,i) = w.vx;
+      prim(m,IVY,k,j,i) = w.vy;
+      prim(m,IVZ,k,j,i) = w.vz;
+      prim(m,IEN,k,j,i) = w.e;
+      bcc(m,IBX,k,j,i) = u.bx;
+      bcc(m,IBY,k,j,i) = u.by;
+      bcc(m,IBZ,k,j,i) = u.bz;
+      for (int n=nmhd; n<(nmhd+nscal); ++n) {
+        prim(m,n,k,j,i) = cons(m,n,k,j,i)/u.d;
+      }
+    }
+  }, Kokkos::Sum<int>(nfloord_), Kokkos::Sum<int>(nfloore_), Kokkos::Sum<int>(nfloort_));
+
+  if (only_testfloors) {
+    pmy_pack->pmesh->ecounter.nfofc += nfloord_;
+  } else {
+    pmy_pack->pmesh->ecounter.neos_dfloor += nfloord_;
+    pmy_pack->pmesh->ecounter.neos_efloor += nfloore_;
+    pmy_pack->pmesh->ecounter.neos_tfloor += nfloort_;
+  }
+
+  return;
+}
+
+//------------------------------------------------------------------------------
+//! \fn void PrimToCons()
+
+void CGLMHD::PrimToCons(const DvceArray5D<Real> &prim, const DvceArray5D<Real> &bcc,
+                        DvceArray5D<Real> &cons, const int il, const int iu,
+                        const int jl, const int ju, const int kl, const int ku) {
+  int &nmhd  = pmy_pack->pmhd->nmhd;
+  int &nscal = pmy_pack->pmhd->nscalars;
+  int &nmb = pmy_pack->nmb_thispack;
+
+  par_for("cglmhd_p2c", DevExeSpace(), 0, (nmb-1), kl, ku, jl, ju, il, iu,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    MHDPrim1D w;
+    w.d  = prim(m,IDN,k,j,i);
+    w.vx = prim(m,IVX,k,j,i);
+    w.vy = prim(m,IVY,k,j,i);
+    w.vz = prim(m,IVZ,k,j,i);
+    w.e  = prim(m,IEN,k,j,i);
+    w.bx = bcc(m,IBX,k,j,i);
+    w.by = bcc(m,IBY,k,j,i);
+    w.bz = bcc(m,IBZ,k,j,i);
+
+    HydCons1D u;
+    SingleP2C_IdealMHD(w, u);
+
+    cons(m,IDN,k,j,i) = u.d;
+    cons(m,IM1,k,j,i) = u.mx;
+    cons(m,IM2,k,j,i) = u.my;
+    cons(m,IM3,k,j,i) = u.mz;
+    cons(m,IEN,k,j,i) = u.e;
+
+    for (int n=nmhd; n<(nmhd+nscal); ++n) {
+      cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
+    }
+  });
+
+  return;
+}
+

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -347,6 +347,32 @@ class IdealMHD : public EquationOfState {
                   const int jl, const int ju, const int kl, const int ku) override;
 };
 
+//------------------------------------------------------------------------------
+//! \class CGLMHD
+//! \brief Skeleton class for CGL (Chew-Goldberger-Low) MHD with collisional
+//!        relaxation toward Braginskii behavior.  This implementation stores the
+//!        parallel and perpendicular pressures in extra primitive variables.  A
+//!        simple collisional isotropization source term can relax these towards
+//!        an isotropic pressure on large scales.  The flux calculation is
+//!        currently identical to the ideal MHD case and should be extended in
+//!        the future.
+
+class CGLMHD : public EquationOfState {
+ public:
+  using EquationOfState::ConsToPrim;
+  using EquationOfState::PrimToCons;
+
+  CGLMHD(MeshBlockPack *pp, ParameterInput *pin);
+  void ConsToPrim(DvceArray5D<Real> &cons, const DvceFaceFld4D<Real> &b,
+                  DvceArray5D<Real> &prim, DvceArray5D<Real> &bcc,
+                  const bool only_testfloors,
+                  const int il, const int iu, const int jl, const int ju,
+                  const int kl, const int ku) override;
+  void PrimToCons(const DvceArray5D<Real> &prim, const DvceArray5D<Real> &bcc,
+                  DvceArray5D<Real> &cons, const int il, const int iu,
+                  const int jl, const int ju, const int kl, const int ku) override;
+};
+
 //----------------------------------------------------------------------------------------
 //! \class IdealSRMHD
 //! \brief Derived class for ideal gas EOS in special relativistic MHD

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -69,6 +69,18 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     }
     nmhd = 5;
 
+  // CGL EOS (anisotropic pressure)
+  } else if (eqn_of_state.compare("cgl") == 0) {
+    if (pmy_pack->pcoord->is_special_relativistic ||
+        pmy_pack->pcoord->is_general_relativistic) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line "<< __LINE__ << std::endl
+                <<"<mhd> eos = cgl currently only implemented for NR"<< std::endl;
+      std::exit(EXIT_FAILURE);
+    } else {
+      peos = new CGLMHD(ppack, pin);
+    }
+    nmhd = 5;
+
   // isothermal EOS
   } else if (eqn_of_state.compare("isothermal") == 0) {
     if (pmy_pack->pcoord->is_special_relativistic ||

--- a/src/mhd/mhd_tasks.cpp
+++ b/src/mhd/mhd_tasks.cpp
@@ -256,6 +256,7 @@ TaskStatus MHD::MHDSrcTerms(Driver *pdrive, int stage) {
   if (psrc->ism_cooling)  psrc->ISMCooling(w0, peos->eos_data, beta_dt, u0);
   if (psrc->rel_cooling)  psrc->RelCooling(w0, peos->eos_data, beta_dt, u0);
   if (psrc->shearing_box) psrc->ShearingBox(w0, bcc0, peos->eos_data, beta_dt, u0);
+  if (psrc->cgl_collisions) psrc->CGLCollisionalRelax(w0, bcc0, beta_dt, u0);
 
   // Add coordinate source terms in GR.  Again, must be computed with only primitives.
   if (pmy_pack->pcoord->is_general_relativistic &&

--- a/src/srcterms/srcterms.cpp
+++ b/src/srcterms/srcterms.cpp
@@ -73,6 +73,22 @@ SourceTerms::SourceTerms(std::string block, MeshBlockPack *pp, ParameterInput *p
   } else {
     shearing_box = false;
   }
+
+  // (6) CGL collisional relaxation
+  cgl_collisions = pin->GetOrAddBoolean(block, "cgl_collisions", false);
+  if (cgl_collisions) {
+    nu_cgl = pin->GetOrAddReal(block, "nu_cgl", 0.0);
+    firehose_coeff = pin->GetOrAddReal(block, "cgl_firehose_coeff", 1.0);
+    mirror_coeff   = pin->GetOrAddReal(block, "cgl_mirror_coeff", 0.5);
+    if (pmy_pack->pmhd->nscalars < 2) {
+      std::cout << "### WARNING in "<< __FILE__ <<" at line "<< __LINE__ << std::endl
+                << "cgl_collisions requires at least two scalar variables" << std::endl;
+    }
+  } else {
+    nu_cgl = 0.0;
+    firehose_coeff = 1.0;
+    mirror_coeff = 0.5;
+  }
 }
 
 //----------------------------------------------------------------------------------------
@@ -231,6 +247,65 @@ void SourceTerms::BeamSource(DvceArray5D<Real> &i0, const Real bdt) {
         if (rad_mask_(m,k,j,i) || fabs(n_0) < n_0_floor_) { i0(m,n,k,j,i) = 0.0; }
       }
     }
+  });
+
+  return;
+}
+
+//------------------------------------------------------------------------------
+//! \fn SourceTerms::CGLCollisionalRelax()
+//! \brief Simple isotropization of parallel and perpendicular pressures with
+//!        microinstability-limited anisotropy.
+
+void SourceTerms::CGLCollisionalRelax(const DvceArray5D<Real> &w0,
+                                      const DvceArray5D<Real> &bcc0,
+                                      const Real bdt,
+                                      DvceArray5D<Real> &u0) {
+  if (nu_cgl <= 0.0) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  int is = indcs.is, ie = indcs.ie;
+  int js = indcs.js, je = indcs.je;
+  int ks = indcs.ks, ke = indcs.ke;
+  int nmb1 = pmy_pack->nmb_thispack - 1;
+  int &nmhd  = pmy_pack->pmhd->nmhd;
+  int &nscal = pmy_pack->pmhd->nscalars;
+
+  if (nscal < 2) return; // need at least two scalar slots
+
+  int ippar = nmhd;       // first scalar slot
+  int ipperp = nmhd + 1;  // second scalar slot
+
+  Real nu = nu_cgl;
+  Real fcoeff = firehose_coeff;
+  Real mcoeff = mirror_coeff;
+  par_for("cgl_relax", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real ppar  = w0(m,ippar,k,j,i);
+    Real pperp = w0(m,ipperp,k,j,i);
+    Real p_sum = ppar + 2.0*pperp;
+    Real p_iso = p_sum/3.0;
+
+    // relaxation toward isotropic pressure
+    Real ppar_r  = ppar  + (p_iso - ppar)*nu*bdt;
+    Real pperp_r = pperp + (p_iso - pperp)*nu*bdt;
+    Real delta   = ppar_r - pperp_r;
+
+    // microinstability limits from Quataert et al. 2023 (arXiv:2303.00468)
+    Real bx = bcc0(m,IBX,k,j,i);
+    Real by = bcc0(m,IBY,k,j,i);
+    Real bz = bcc0(m,IBZ,k,j,i);
+    Real B2 = bx*bx + by*by + bz*bz;
+    Real delta_max =  mcoeff*B2;
+    Real delta_min = -fcoeff*B2;
+
+    delta = fmin(fmax(delta, delta_min), delta_max);
+
+    Real ppar_new  = (p_sum + 2.0*delta)/3.0;
+    Real pperp_new = (p_sum -    delta)/3.0;
+
+    u0(m,ippar,k,j,i) += ppar_new - ppar;
+    u0(m,ipperp,k,j,i) += pperp_new - pperp;
   });
 
   return;

--- a/src/srcterms/srcterms.hpp
+++ b/src/srcterms/srcterms.hpp
@@ -39,6 +39,7 @@ class SourceTerms {
   bool rel_cooling;
   bool beam;
   bool shearing_box, shearing_box_r_phi;
+  bool cgl_collisions;
 
   // new timestep
   Real dtnew;
@@ -57,6 +58,11 @@ class SourceTerms {
   // beam source
   Real dii_dt;
 
+  // collisional isotropization
+  Real nu_cgl;
+  Real firehose_coeff;
+  Real mirror_coeff;
+
   // shearing box
   Real qshear, omega0;
 
@@ -68,6 +74,9 @@ class SourceTerms {
   void RelCooling(const DvceArray5D<Real> &w0, const EOS_Data &eos,
                   const Real dt, DvceArray5D<Real> &u0);
   void BeamSource(DvceArray5D<Real> &i0, const Real dt);
+  void CGLCollisionalRelax(const DvceArray5D<Real> &w0,
+                           const DvceArray5D<Real> &bcc0,
+                           const Real dt, DvceArray5D<Real> &u0);
   void ShearingBox(const DvceArray5D<Real> &w0, const EOS_Data &eos_data, const Real bdt,
                    DvceArray5D<Real> &u0);
   void ShearingBox(const DvceArray5D<Real> &w0, const DvceArray5D<Real> &bcc0,


### PR DESCRIPTION
## Summary
- add a skeleton `CGLMHD` EOS class
- register new source term for collisional isotropization
- hook `cgl_collisions` into the MHD time integration
- add anisotropy limiter with coefficients from Quataert et al. (2023)

## Testing
- `git status --short`
